### PR TITLE
Upgrade dependency of cmake to 3.x to use GNUInstallDirs function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,20 +1,12 @@
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.0.2)
 
+include(GNUInstallDirs)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/QEverCloud/cmake/modules")
 include(QEverCloudCMakePolicies)
 SET_POLICIES()
 
-if("${CMAKE_MAJOR_VERSION}" GREATER "2")
-  project(QEverCloud
-          VERSION 3.0.1)
-else()
-  project(QEverCloud)
-  set(PROJECT_VERSION_MAJOR "3")
-  set(PROJECT_VERSION_MINOR "0")
-  set(PROJECT_VERSION_PATCH "1")
-  set(PROJECT_VERSION_COUNT 3)
-  set(PROJECT_VERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}")
-endif()
+project(QEverCloud
+        VERSION 3.0.1)
 
 set(PROJECT_VENDOR "Dmitry Ivanov")
 set(PROJECT_COPYRIGHT_YEAR "2015-2016")


### PR DESCRIPTION
OK. This PR only act as a suggestion. Feel free to close it if you don't like.

To fit into Debian's Multiarch requirement more easily (and write less in `debian/rules` file), it is recommended to [use CMake's GNUInstallDirs function](https://wiki.debian.org/Multiarch/Implementation#CMake). However this function only exists in CMake 3.x, so I have to bump minimum CMake version requirement.